### PR TITLE
Add color patch component to guide

### DIFF
--- a/_includes/color-patch.html
+++ b/_includes/color-patch.html
@@ -1,0 +1,19 @@
+<div class="c-color-patch c-color-patch__{{ include.type }}">
+  <div class="c-color-patch__block" style="background: #{{ include.hex }};"></div>
+  <div class="c-color-patch__name c-color-patch__column">
+    <div class="c-color-patch__type">Color name</div>
+    <div class="c-color-patch__value">{{ include.name }}</div>
+  </div>
+  <div class="c-color-patch__hex c-color-patch__column">
+    <div class="c-color-patch__type">HEX</div>
+    <div class="c-color-patch__value">&#35;{{ include.hex }}</div>
+  </div>
+  <div class="c-color-patch__rgb c-color-patch__column">
+    <div class="c-color-patch__type">RGB</div>
+    <div class="c-color-patch__value">{{ include.rgb }}</div>
+  </div>
+  <div class="c-color-patch__cmyk c-color-patch__column">
+    <div class="c-color-patch__type">CMYK</div>
+    <div class="c-color-patch__value">{{ include.cmyk }}</div>
+  </div>
+</div>

--- a/_sass/abstracts/_variables.scss
+++ b/_sass/abstracts/_variables.scss
@@ -41,26 +41,44 @@
  * 1) Main identifiable colors involved in creating the UI
  *    Feel free to add your brand's color palette here.
  */
- $brand-primary-01: #4ba6dd; // Light blue from logo
- $brand-primary-02: #3773a1; // Med. blue from logo
- $brand-primary-03: #204f72; // Dark blue from logo
- $brand-secondary-01: #0e4266; // Blog's Company section
- $brand-secondary-02: #53ae52; // Blog's Spatial Analysis section
- $brand-secondary-03: #d45db0; // Blog's Events section
- $brand-secondary-04: #f1b210; // Blog's Software Dev section 
+$brand-sky: #4ba6dd; // Light blue from logo
+$brand-denim: #3773a1; // Med. blue from logo
+$brand-midnight: #204f72; // Dark blue from logo
+
+$brand-sapphire: #0e4266; // Blog's Company section
+$brand-light-forest: #53ae52; // Blog's Spatial Analysis section
+$brand-med-orchid: #d45db0; // Blog's Events section
+$brand-med-gold: #f1b210; // Blog's Software Dev section 
+
+ $brand-primary-01: $brand-sky;
+ $brand-primary-02: $brand-denim;
+ $brand-primary-03: $brand-midnight;
+ $brand-secondary-01: $brand-sapphire;
+ $brand-secondary-02: $brand-light-forest;
+ $brand-secondary-03: $brand-med-orchid;
+ $brand-secondary-04: $brand-med-gold;
  $brand-semitransparent: rgba($brand-primary-01, 0.15);
 /**
  * Neutral Colors
  * 1) Neutral colors are grayscale values used throughout the application
  */
+$brand-ink: #27323D;
+$brand-granite: #4D6379;
+$brand-slate: #7C94AC;
+$brand-pewter: #B8C5D2;
+$brand-steel: #D0D9E1;
+$brand-porcelain: #E5EAEE;
+$brand-off-white: #F4F6F8;
+
+
 $color-white: #ffffff;
-$color-gray-100: #F4F6F8;
-$color-gray-200: #E5EAEE;
-$color-gray-300: #D0D9E1;
-$color-gray-400: #B8C5D2;
-$color-gray-500: #7C94AC;
-$color-gray-600: #4D6379;
-$color-gray-900: #27323D;
+$color-gray-100: $brand-off-white;
+$color-gray-200: $brand-porcelain;
+$color-gray-300: $brand-steel;
+$color-gray-400: $brand-pewter;
+$color-gray-500: $brand-slate;
+$color-gray-600: $brand-granite;
+$color-gray-900: $brand-ink;
 $color-black: #000;
 
 /**

--- a/_sass/abstracts/_variables.scss
+++ b/_sass/abstracts/_variables.scss
@@ -176,7 +176,7 @@ $font-weight-normal: 400;
  * Max Width
  */
 $l-max-width: 60rem;
-$l-max-width-narrow: 36rem;
+$l-max-width-narrow: 45rem;
 
 
 

--- a/_sass/components/_color-patch.scss
+++ b/_sass/components/_color-patch.scss
@@ -1,0 +1,87 @@
+/*------------------------------------*\
+    #COLOR PATCH
+\*------------------------------------*/
+
+/**
+ * Block Containing Title and List
+ */
+.c-color-patch__containe {
+  display: flex;
+}
+
+.c-color-patch {
+  background-color: $color-white;
+  border: 1px solid $color-gray-200;
+	padding: 1rem;
+  margin-bottom: 2rem;
+}
+
+.c-color-patch__card {
+  display: inline-block;
+  margin-right: 0.33%;
+  width: 32.33%;
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  .c-color-patch__column {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: $pad-compact 0;
+  }
+
+  .c-color-patch__name {
+    border-bottom: 1px solid $color-gray-200;
+    margin-top: $pad-compact;
+
+    .c-color-patch__type {
+      display: none;
+    }
+
+    .c-color-patch__value {
+      color: $color-black;
+      font-size: $font-size-med;
+      font-weight: $font-weight-medium;
+    }
+  }
+}
+
+.c-color-patch__type {
+  color: $color-gray-500;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+}
+
+.c-color-patch__row {
+  display: flex;
+  justify-content: space-between;
+
+  .c-color-patch__block {
+    flex: 0 1 45px;
+
+  }
+
+}
+
+/**
+ * Visible color block
+ */
+.c-color-patch__block {
+  width: 100%;
+
+  &:after {
+    content: "";
+    display: block;
+    padding-bottom: 100%;
+  }
+}
+
+.c-color-patch__type {
+	// list-style: disc;
+	// margin-left: 1em;
+}
+.c-block__link {
+	 // text-decoration: underline;
+}

--- a/_sass/components/_color-patch.scss
+++ b/_sass/components/_color-patch.scss
@@ -54,6 +54,12 @@
   font-size: $font-size-sm;
 }
 
+.c-color-patch__hex {
+  .c-color-patch__value {
+    text-transform: lowercase;
+  }
+}
+
 /**
  * Card-style color patch styles
  */

--- a/_sass/components/_color-patch.scss
+++ b/_sass/components/_color-patch.scss
@@ -3,19 +3,60 @@
 \*------------------------------------*/
 
 /**
- * Block Containing Title and List
+ * Visible color block
  */
-.c-color-patch__containe {
-  display: flex;
+.c-color-patch__block {
+  border-radius: $border-radius;
+  width: 100%;
+  
+  &:after {
+    content: "";
+    display: block;
+  }
 }
 
+/**
+ * Card is a square
+ */
+.c-color-patch__card {
+  .c-color-patch__block {
+
+    &:after {
+      padding-bottom: 100%;
+    }
+  }
+}
+
+/**
+ * Row is a rectangle
+ */
+.c-color-patch__row {
+  .c-color-patch__block {
+
+    &:after {
+      padding-bottom: 50%;
+    }
+  }
+}
+
+/**
+ * General block styles
+ */
 .c-color-patch {
   background-color: $color-white;
   border: 1px solid $color-gray-200;
-	padding: 1rem;
-  margin-bottom: 2rem;
+	padding: $pad-normal;
+  font-weight: $font-weight-medium;
 }
 
+.c-color-patch__type {
+  color: $color-gray-500;
+  font-size: $font-size-sm;
+}
+
+/**
+ * Card-style color patch styles
+ */
 .c-color-patch__card {
   display: inline-block;
   margin-right: 0.33%;
@@ -48,40 +89,30 @@
   }
 }
 
-.c-color-patch__type {
-  color: $color-gray-500;
-  font-size: $font-size-sm;
-  font-weight: $font-weight-medium;
-}
-
+/**
+ * Row-style color patch styles
+ */
 .c-color-patch__row {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
+  margin-bottom: $pad-compact;
 
   .c-color-patch__block {
-    flex: 0 1 45px;
-
+    flex: 0 0 85px;
+    margin-right: $pad-normal;
   }
 
-}
+  .c-color-patch__column {
+    margin-right: $pad-normal;
+    flex: 1;
 
-/**
- * Visible color block
- */
-.c-color-patch__block {
-  width: 100%;
-
-  &:after {
-    content: "";
-    display: block;
-    padding-bottom: 100%;
+    &:last-child {
+      margin-right: 0;
+    }
   }
-}
-
-.c-color-patch__type {
-	// list-style: disc;
-	// margin-left: 1em;
-}
-.c-block__link {
-	 // text-decoration: underline;
+  .c-color-patch__name {
+    @media all and (51.250em) {
+      flex: 1 20%;
+    }
+  }
 }

--- a/_sass/components/_text-passage.scss
+++ b/_sass/components/_text-passage.scss
@@ -7,7 +7,8 @@
  */
 .c-text-passage {
 	p {
-		margin-bottom: 1rem;
+		margin-bottom: $pad-normal;
+		max-width: $l-max-width-narrow;
 	}
 
 	/**

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -29,7 +29,9 @@
  *    kinds of displays
  */
 .l-linelength-container {
-  max-width: 35rem;
+  @media all and (min-width:87.500em) {
+    width: $l-max-width;
+  }
 }
 
 
@@ -54,10 +56,14 @@
 .l-page-layout__main {
   display: flex;
   flex: 1;
-  align-items: center;
+  align-items: stretch;
   overflow-y: scroll;
   -ms-flex-direction: column;
   flex-direction: column;
+
+  @media all and (min-width:87.500em) {
+    align-items: center;
+  }
 }
 
 /**

--- a/css/main.scss
+++ b/css/main.scss
@@ -65,6 +65,7 @@
 @import "components/buttons";
 @import "components/button-group";
 @import "components/card";
+@import "components/color-patch";
 @import "components/footer-nav";
 @import "components/footer";
 @import "components/header";

--- a/design/03-colors.md
+++ b/design/03-colors.md
@@ -17,7 +17,7 @@ The three main colors that make up Azavea's logo are the basis of color use in o
 
 {% include color-patch.html
   type = "card"
-  name = "Light blue"
+  name = "Sky"
   hex = "4ba6dd"
   rgb = "75, 166, 221"
   cmyk = "66, 25, 0, 13"
@@ -25,7 +25,7 @@ The three main colors that make up Azavea's logo are the basis of color use in o
 
 {% include color-patch.html
   type = "card"
-  name = "Medium blue"
+  name = "Denim"
   hex = "3773a1"
   rgb = "55, 115, 161"
   cmyk = "66, 29, 0, 37"
@@ -33,7 +33,7 @@ The three main colors that make up Azavea's logo are the basis of color use in o
 
 {% include color-patch.html
   type = "card"
-  name = "Dark blue"
+  name = "Midnight"
   hex = "204f72"
   rgb = "32, 79, 114"
   cmyk = "72, 31, 0, 55"
@@ -44,7 +44,7 @@ Colors from our secondary palette should be used sparingly. They are for categor
 
 {% include color-patch.html
   type = "row"
-  name = "Company"
+  name = "Sapphire"
   hex = "0e4266"
   rgb = "14, 66, 102"
   cmyk = "86, 35, 0, 60"
@@ -52,7 +52,7 @@ Colors from our secondary palette should be used sparingly. They are for categor
 
 {% include color-patch.html
   type = "row"
-  name = "Spatial analysis"
+  name = "Light forest"
   hex = "53ae52"
   rgb = "83, 174, 82"
   cmyk = "52, 0, 53, 32"
@@ -60,7 +60,7 @@ Colors from our secondary palette should be used sparingly. They are for categor
 
 {% include color-patch.html
   type = "row"
-  name = "Events"
+  name = "Medium orchid"
   hex = "d45db0"
   rgb = "212, 93, 176"
   cmyk = "0, 56, 17, 17"
@@ -68,7 +68,7 @@ Colors from our secondary palette should be used sparingly. They are for categor
 
 {% include color-patch.html
   type = "row"
-  name = "Software development"
+  name = "Medium gold"
   hex = "f1b210"
   rgb = "241, 178, 16"
   cmyk = "0, 26, 93, 5"

--- a/design/03-colors.md
+++ b/design/03-colors.md
@@ -18,24 +18,24 @@ The three main colors that make up Azavea's logo are the basis of color use in o
 {% include color-patch.html
   type = "card"
   name = "Sky"
-  hex = "4ba6dd"
-  rgb = "75, 166, 221"
+  hex =  "4ba6dd"
+  rgb =  "75, 166, 221"
   cmyk = "66, 25, 0, 13"
 %}
 
 {% include color-patch.html
   type = "card"
   name = "Denim"
-  hex = "3773a1"
-  rgb = "55, 115, 161"
+  hex =  "3773a1"
+  rgb =  "55, 115, 161"
   cmyk = "66, 29, 0, 37"
 %}
 
 {% include color-patch.html
   type = "card"
   name = "Midnight"
-  hex = "204f72"
-  rgb = "32, 79, 114"
+  hex =  "204f72"
+  rgb =  "32, 79, 114"
   cmyk = "72, 31, 0, 55"
 %}
 
@@ -45,34 +45,95 @@ Colors from our secondary palette should be used sparingly. They are for categor
 {% include color-patch.html
   type = "row"
   name = "Sapphire"
-  hex = "0e4266"
-  rgb = "14, 66, 102"
+  hex =  "0e4266"
+  rgb =  "14, 66, 102"
   cmyk = "86, 35, 0, 60"
 %}
 
 {% include color-patch.html
   type = "row"
   name = "Light forest"
-  hex = "53ae52"
-  rgb = "83, 174, 82"
+  hex =  "53ae52"
+  rgb =  "83, 174, 82"
   cmyk = "52, 0, 53, 32"
 %}
 
 {% include color-patch.html
   type = "row"
   name = "Medium orchid"
-  hex = "d45db0"
-  rgb = "212, 93, 176"
+  hex =  "d45db0"
+  rgb =  "212, 93, 176"
   cmyk = "0, 56, 17, 17"
 %}
 
 {% include color-patch.html
   type = "row"
   name = "Medium gold"
-  hex = "f1b210"
-  rgb = "241, 178, 16"
+  hex =  "f1b210"
+  rgb =  "241, 178, 16"
   cmyk = "0, 26, 93, 5"
 %}
+
+### Neutral colors
+Our grayscale is based upon the Azavea <strong>Midnight</strong> color. These colors all have a blueish tint as a result.
+
+{% include color-patch.html
+  type = "row"
+  name = "Ink"
+  hex =  "27323D"
+  rgb =  "39, 50, 61"
+  cmyk = "36, 18, 0, 76"
+%}
+
+{% include color-patch.html
+  type = "row"
+  name = "Granite"
+  hex =  "4D6379"
+  rgb =  "77, 99, 121"
+  cmyk = "36, 18, 0, 53"
+%}
+
+{% include color-patch.html
+  type = "row"
+  name = "Slate"
+  hex =  "7C94AC"
+  rgb =  "124, 148, 172"
+  cmyk = "28, 14, 0, 33"
+%}
+
+{% include color-patch.html
+  type = "row"
+  name = "Pewter"
+  hex =  "B8C5D2"
+  rgb =  "184, 197, 210"
+  cmyk = "12, 6, 0, 18"
+%}
+
+{% include color-patch.html
+  type = "row"
+  name = "Steel"
+  hex =  "D0D9E1"
+  rgb =  "208, 217, 225"
+  cmyk = "8, 4, 0, 12"
+%}
+
+{% include color-patch.html
+  type = "row"
+  name = "Porcelain"
+  hex =  "E5EAEE"
+  rgb =  "229, 234, 238"
+  cmyk = "4, 2, 0, 7"
+%}
+
+{% include color-patch.html
+  type = "row"
+  name = "Off-white"
+  hex =  "F4F6F8"
+  rgb =  "244, 246, 248"
+  cmyk = "2, 1, 0, 3"
+%}
+
+
 
 ## Assets
 

--- a/design/03-colors.md
+++ b/design/03-colors.md
@@ -8,24 +8,71 @@ description: Azavea's color scheme helps perpetuate our personality. We try to u
 
 ---
 
-As a company, Azavea is committed to complying with (WGAC 2.0 AA contrast ratios.)[] Refer to the (Accessibility)[] page for more information and helpful tools.
+As a company, Azavea is committed to complying with [WGAC 2.0 AA contrast ratios.]() Refer to the [Resources](/resources.html) page for helpful tools.
 
 ## Color Usage
 
 ### Primary Palette
 The three main colors that make up Azavea's logo are the basis of color use in our website and print materials.
 
-[primary color palette components here]
+{% include color-patch.html
+  type = "card"
+  name = "Light blue"
+  hex = "4ba6dd"
+  rgb = "75, 166, 221"
+  cmyk = "66, 25, 0, 13"
+%}
+
+{% include color-patch.html
+  type = "card"
+  name = "Medium blue"
+  hex = "3773a1"
+  rgb = "55, 115, 161"
+  cmyk = "66, 29, 0, 37"
+%}
+
+{% include color-patch.html
+  type = "card"
+  name = "Dark blue"
+  hex = "204f72"
+  rgb = "32, 79, 114"
+  cmyk = "72, 31, 0, 55"
+%}
 
 ### Supporting colors
 Colors from our secondary palette should be used sparingly. They are for categorical differentiation (e.g. in the blog) or as a contrasting color to the Azavean blues.
 
-[secondary color palette components here]
+{% include color-patch.html
+  type = "row"
+  name = "Company"
+  hex = "0e4266"
+  rgb = "14, 66, 102"
+  cmyk = "86, 35, 0, 60"
+%}
 
-### Grayscale
-Our grayscale is based upon the Azavean tertiary color. All grays have a blue tint. Use these grays in print and web whereever possible.
+{% include color-patch.html
+  type = "row"
+  name = "Spatial analysis"
+  hex = "53ae52"
+  rgb = "83, 174, 82"
+  cmyk = "52, 0, 53, 32"
+%}
 
-[grayscale color palette components here]
+{% include color-patch.html
+  type = "row"
+  name = "Events"
+  hex = "d45db0"
+  rgb = "212, 93, 176"
+  cmyk = "0, 56, 17, 17"
+%}
+
+{% include color-patch.html
+  type = "row"
+  name = "Software development"
+  hex = "f1b210"
+  rgb = "241, 178, 16"
+  cmyk = "0, 26, 93, 5"
+%}
 
 ## Assets
 


### PR DESCRIPTION
# Overview
This ticket adds a new component in `_includes` called `color-patch.html`. Color patches can have a card or row layout.

# Demo
Cards
<img width="963" alt="screen shot 2018-03-05 at 11 46 32 am" src="https://user-images.githubusercontent.com/5672295/36988381-be7ef7c2-206c-11e8-8be6-10613f8653d7.png">
Rows
<img width="963" alt="screen shot 2018-03-05 at 11 46 26 am" src="https://user-images.githubusercontent.com/5672295/36988380-be62252a-206c-11e8-8750-900b1f86eb4a.png">

# Notes
- I've taken a stab at naming these colors. Let me know if any of the names I chose look questionable to you.
- This won't be fully responsive #10

# Testing
- You can look at the screenshot names or `git pull` from `develop`, run `jekyll serve` on this branch, and review

Closes #4